### PR TITLE
Depend on Xapp 2.2.0

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,11 +12,11 @@ Architecture: all
 Depends:
     gir1.2-glib-2.0,
     gir1.2-gtk-3.0 (>= 3.22.0),
-    gir1.2-xapp-1.0 (>= 1.6.0),
+    gir1.2-xapp-1.0 (>= 2.2.0),
     gir1.2-gspell-1,
     python3,
     python3-gi,
-    python3-xapp (>= 1.6.0),
+    python3-xapp (>= 2.2.0),
     ${misc:Depends},
     ${python3:Depends}
 Description: Sticky Notes app


### PR DESCRIPTION
Sticky uses stylemanager and code added in Xapp in 2.2.0.