### PR TITLE
Fix exception in generate_previews()

### DIFF
--- a/usr/lib/sticky/manager.py
+++ b/usr/lib/sticky/manager.py
@@ -208,7 +208,8 @@ class Note(GObject.Object):
         super(Note, self).__init__()
         self.info = info
         self.text = info['text']
-        if info['title'] in [None, '']:
+        print(info)
+        if not 'title'in info or info['title'] in [None, '']:
             self.title = _("Untitled")
         else:
             self.title = info['title']


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/lib/sticky/manager.py", line 335, in generate_previews
    model.append(Note(note))
  File "/usr/lib/sticky/manager.py", line 211, in __init__
    if info['title'] in [None, '']:
KeyError: 'title'