### PR TITLE
[WIP] add complete transparency

### DIFF
--- a/usr/lib/sticky/sticky.py
+++ b/usr/lib/sticky/sticky.py
@@ -60,7 +60,8 @@ COLORS = {
     'purple': _("Purple"),
     'teal': _("Teal"),
     'orange': _("Orange"),
-    'magenta': _("Magenta")
+    'magenta': _("Magenta"),
+    'transparent':_("transparent")
 }
 
 COLOR_CODES = {
@@ -71,7 +72,8 @@ COLOR_CODES = {
     'purple': "#a553ff",
     'teal': "#41ffed",
     'orange': "#ffa939",
-    'magenta': "#ff7ff7"
+    'magenta': "#ff7ff7",
+    'transparent':"#ffffff00"
 }
 
 SHORTCUTS = {
@@ -227,6 +229,10 @@ class Note(Gtk.Window):
         self.view.set_right_margin(10)
         self.view.set_top_margin(10)
         self.view.set_bottom_margin(10)
+        self.view.set_app_paintable(True)
+        self.view.override_background_color(Gtk.StateFlags.NORMAL, Gdk.RGBA(0, 0, 0, 0))
+        self.view.get_style_context().add_class("note-textview")
+        self.view.override_background_color(Gtk.StateFlags.NORMAL, None)
         self.view.connect('populate-popup', lambda w, p: self.add_context_menu_items(p))
         self.view.connect('key-press-event', self.on_key_press)
         self.view_style_manager = XApp.StyleManager(widget=self.view)
@@ -529,10 +535,18 @@ class Note(Gtk.Window):
         if color == self.color:
             return
 
-        self.get_style_context().remove_class(self.color)
-        self.get_style_context().add_class(color)
-        self.color = color
+        ctx = self.get_style_context()
+        ctx.remove_class(self.color)
+        ctx.add_class(color)
 
+        tv_ctx = self.view.get_style_context()
+
+        if color == "transparent":
+            tv_ctx.add_class("note-transparent")
+        else:
+            tv_ctx.remove_class("note-transparent")
+
+        self.color = color
         self.emit('update')
 
     def set_font(self, *args):

--- a/usr/share/sticky/sticky.css
+++ b/usr/share/sticky/sticky.css
@@ -455,3 +455,24 @@ button.magenta {
     color: #303030;
     box-shadow: 1px 1px 2px;
 }
+
+.note-transparent,
+.note-transparent textview,
+.note-transparent text {
+    background-color: transparent;
+    background-image: none;
+}
+
+#sticky-note.transparent textview text,
+#sticky-note.transparent textview,
+#sticky-note.transparent {
+background-color: transparent;
+background-image: none;
+}
+
+#sticky-note.transparent textview text {
+background-color: rgba(0, 0, 0, 0.4);
+color: white;
+caret-color: white;
+border-radius: 6px;
+}


### PR DESCRIPTION
Add full transparency mode

Implements a functional transparency mode. GTK3 does not provide a native invert or automatic contrast adjustment, so text readability can be poor depending on background brightness.

Requests #157 #137 have voiced a request to add this feature.

Files Modified: usr/lib/sticky/sticky.py - addition of transparent color and color mode, added exceptions to transparency
usr/share/sticky/sticky.css: addition of a dark area in the gtk.textView to enhance readability in light backgrounds

Screenshot:
<img width="325" height="310" alt="ksnip_20260328-180837" src="https://github.com/user-attachments/assets/6338c71f-52f3-49e5-a0b8-c3fa4176100f" /> transparency shown to be functional

<img width="898" height="616" alt="image" src="https://github.com/user-attachments/assets/ba6f5cf5-d34a-40d8-922f-b05c0bda1369" /> demonstration of colors working

